### PR TITLE
Removed getJobStateInfoLine() from BatchEuphoriaJobManager and its su…

### DIFF
--- a/src/main/groovy/de/dkfz/roddy/execution/jobs/BatchEuphoriaJobManager.groovy
+++ b/src/main/groovy/de/dkfz/roddy/execution/jobs/BatchEuphoriaJobManager.groovy
@@ -352,30 +352,6 @@ abstract class BatchEuphoriaJobManager<C extends Command> {
      */
     abstract String[] peekLogFile(BEJob job)
 
-    /**
-     * Stores a new job jobState info to an execution contexts job jobState log file.
-     *
-     * @param job
-     */
-    String getJobStateInfoLine(BEJob job) {
-        String millis = "" + System.currentTimeMillis()
-        millis = millis.substring(0, millis.length() - 3)
-        String code = "255"
-        if (job.getJobState() == JobState.UNSTARTED)
-            code = "N"
-        else if (job.getJobState() == JobState.ABORTED)
-            code = "A"
-        else if (job.getJobState() == JobState.OK)
-            code = "C"
-        else if (job.getJobState() == JobState.FAILED)
-            code = "E"
-        if (null != job.getJobID())
-            return String.format("%s:%s:%s", job.getJobID(), code, millis)
-
-        logger.postSometimesInfo("Did not store info for job " + job.getJobName() + ", job id was null.")
-        return null
-    }
-
     String getLogFileName(BEJob p) {
         return p.getJobName() + ".o" + p.getJobID()
     }

--- a/src/main/groovy/de/dkfz/roddy/execution/jobs/JobState.java
+++ b/src/main/groovy/de/dkfz/roddy/execution/jobs/JobState.java
@@ -13,7 +13,7 @@ import java.io.Serializable;
  */
 public enum JobState implements Serializable {
     /**
-     * BEJob is still running
+     * BEJob is still running; according to cluster monitor
      */
     RUNNING,
     /**
@@ -49,7 +49,7 @@ public enum JobState implements Serializable {
     /**
      * Jobs which were started and which might be running.
      */
-    STARTED,
+    STARTED,  // according to job state logfile
     HOLD,
     QUEUED,
     /**
@@ -85,9 +85,9 @@ public enum JobState implements Serializable {
             status = ABORTED;
         else if (stateString.equals("N"))   //N??
             status = FAILED;
-        else if (stateString.equals("60000") || stateString.equals("ABORTED"))   //Aborted due to failed parent job or due to a missing dependency.
+        else if (stateString.equals("ABORTED"))   //Aborted due to failed parent job or due to a missing dependency.
             status = ABORTED;
-        else if (stateString.equals("57427") || stateString.equals("STARTED"))   //Started and possibly running
+        else if (stateString.equals("STARTED"))   //Started and possibly running
             status = STARTED;
         else
             status = FAILED;

--- a/src/main/groovy/de/dkfz/roddy/execution/jobs/direct/synchronousexecution/DirectSynchronousExecutionJobManager.groovy
+++ b/src/main/groovy/de/dkfz/roddy/execution/jobs/direct/synchronousexecution/DirectSynchronousExecutionJobManager.groovy
@@ -157,12 +157,6 @@ public class DirectSynchronousExecutionJobManager extends BatchEuphoriaJobManage
         return new String[0];
     }
 
-    @Override
-    public String getJobStateInfoLine(BEJob job) {
-
-        return null;
-    }
-
 //    @Override
 //    public void queryJobAbortion(List executedJobs,BEExecutionService executionService) {
 //        TODO something with kill


### PR DESCRIPTION
…bclass DirectSynchronousExecutionJobManager. The method is static, does not belong in this class and is only used in Roddy.