### PR TITLE
Further refactorings of BEJob and BEJobID.

### DIFF
--- a/src/main/groovy/de/dkfz/roddy/BEIntegrationTestStarter.groovy
+++ b/src/main/groovy/de/dkfz/roddy/BEIntegrationTestStarter.groovy
@@ -86,19 +86,21 @@ class BEIntegrationTestStarter {
 
 
     private static void testJobWithPipedScript(BatchEuphoriaJobManager jobManager) {
-        BEJob testJobWithPipedScript = new BEJob("batchEuphoriaTestJob", null, testScript, null, resourceSet, null, ["a": "value"], null, jobManager)
+        BEJob testJobWithPipedScript = new BEJob("batchEuphoriaTestJob", null, testScript, null, resourceSet, ["a": "value"], jobManager)
         singleJobTest(jobManager, testJobWithPipedScript)
     }
 
     private static void testJobWithFile(BatchEuphoriaJobManager jobManager) {
-        BEJob testJobWithFile = new BEJob("batchEuphoriaTestJob", batchEuphoriaTestScript, null, null, resourceSet, null, ["a": "value"], null, jobManager)
+        BEJob testJobWithFile = new BEJob("batchEuphoriaTestJob", batchEuphoriaTestScript, null, null, resourceSet, ["a": "value"], jobManager)
         singleJobTest(jobManager, testJobWithFile)
     }
 
     private static void testMultipleJobsWithFile(BatchEuphoriaJobManager jobManager) {
-        BEJob testParent = new BEJob("batchEuphoriaTestJob_Parent", batchEuphoriaTestScript, null, null, resourceSet, null, ["a": "value"], null, jobManager)
-        BEJob testJobChild1 = new BEJob("batchEuphoriaTestJob_Child1", batchEuphoriaTestScript, null, null, resourceSet, null, ["a": "value"], [testParent.runResult.jobID], jobManager)
-        BEJob testJobChild2 = new BEJob("batchEuphoriaTestJob_Child2", batchEuphoriaTestScript, null, null, resourceSet, null, ["a": "value"], [testParent.runResult.jobID, testJobChild1.runResult.jobID], jobManager)
+        BEJob testParent = new BEJob("batchEuphoriaTestJob_Parent", batchEuphoriaTestScript, null, null, resourceSet, ["a": "value"], jobManager)
+        BEJob testJobChild1 = new BEJob("batchEuphoriaTestJob_Child1", batchEuphoriaTestScript, null, null, resourceSet, ["a": "value"], jobManager)
+                .addParentJobIDs([testParent.runResult.jobID])
+        BEJob testJobChild2 = new BEJob("batchEuphoriaTestJob_Child2", batchEuphoriaTestScript, null, null, resourceSet, ["a": "value"], jobManager)
+                .addParentJobIDs([testParent.runResult.jobID, testJobChild1.runResult.jobID])
         multipleJobsTest(jobManager, [testParent, testJobChild1, testJobChild2])
     }
 

--- a/src/main/groovy/de/dkfz/roddy/execution/jobs/BEJobID.groovy
+++ b/src/main/groovy/de/dkfz/roddy/execution/jobs/BEJobID.groovy
@@ -16,10 +16,14 @@ import groovy.transform.CompileStatic
  * Jobs don't directly have a JobID. The reference is rather the other way around (see job field of BEJobID).
  */
 @CompileStatic
-abstract class BEJobID {
+class BEJobID {
 
     public final BEJob job
     private final String id
+
+    BEJobID(BEJob job) {
+        this.job = job
+    }
 
     BEJobID(String id, BEJob job) {
         this.id = id
@@ -38,6 +42,10 @@ abstract class BEJobID {
         return getId()
     }
 
+    String toString() {
+        return(id)
+    }
+
     static FakeJobID getNotExecutedFakeJob(BEJob job) {
         return FakeBEJob.getNotExecutedFakeJob(job, false)
     }
@@ -54,12 +62,8 @@ abstract class BEJobID {
         return FakeBEJob.getFileExistedFakeJob(new FakeBEJob(infoObject), false)
     }
 
-    BEJobID(BEJob job) {
-        this.job = job
-    }
-
     @Deprecated
-    static abstract class FakeJobID extends BEJobID {
+    static class FakeJobID extends BEJobID {
         FakeJobID(BEJob job) {
             super(job)
         }

--- a/src/main/groovy/de/dkfz/roddy/execution/jobs/BatchEuphoriaJobManager.groovy
+++ b/src/main/groovy/de/dkfz/roddy/execution/jobs/BatchEuphoriaJobManager.groovy
@@ -128,10 +128,10 @@ abstract class BatchEuphoriaJobManager<C extends Command> {
 
     abstract C createCommand(GenericJobInfo jobInfo)
 
-    abstract C createCommand(BEJob job, String jobName, List<ProcessingCommands> processingCommands, File tool, Map<String, String> parameters, List<String> dependencies, List<String> arraySettings)
+    abstract C createCommand(BEJob job, String jobName, List<ProcessingCommands> processingCommands, File tool, Map<String, String> parameters, List<String> dependencies)
 
     C createCommand(BEJob job, File tool, List<String> dependencies) {
-        C c = (C) createCommand(job, job.jobName, job.getListOfProcessingCommand(), tool, job.getParameters(), dependencies, job.arrayIndices)
+        C c = (C) createCommand(job, job.jobName, job.getListOfProcessingCommand(), tool, job.getParameters(), dependencies)
         c.setJob(job)
         return c
     }

--- a/src/main/groovy/de/dkfz/roddy/execution/jobs/FakeBEJob.groovy
+++ b/src/main/groovy/de/dkfz/roddy/execution/jobs/FakeBEJob.groovy
@@ -15,7 +15,7 @@ import groovy.transform.CompileStatic
 @CompileStatic
 class FakeBEJob extends BEJob {
     FakeBEJob() {
-        super("Fakejob", null,null, "", null, [], [:], [], null)
+        super("Fakejob", null,null, "", null, [:], null)
     }
 
     public FakeBEJob(Object context) {

--- a/src/main/groovy/de/dkfz/roddy/execution/jobs/JobState.java
+++ b/src/main/groovy/de/dkfz/roddy/execution/jobs/JobState.java
@@ -12,9 +12,9 @@ import java.io.Serializable;
  * A generic jobState for jobs.
  */
 public enum JobState implements Serializable {
+    UNSTARTED, // Initial state before submission.
     HOLD,
     QUEUED,
-    UNSTARTED,
     /**
      * It is used only in Roddy.
      */

--- a/src/main/groovy/de/dkfz/roddy/execution/jobs/cluster/lsf/rest/BatchEuphoriaJobManagerAdapter.groovy
+++ b/src/main/groovy/de/dkfz/roddy/execution/jobs/cluster/lsf/rest/BatchEuphoriaJobManagerAdapter.groovy
@@ -166,7 +166,7 @@ class BatchEuphoriaJobManagerAdapter extends ClusterJobManager {
     }
 
     @Override
-    Command createCommand(BEJob job, String jobName, List processingCommands, File tool, Map parameters, List dependencies, List arraySettings) {
+    Command createCommand(BEJob job, String jobName, List processingCommands, File tool, Map parameters, List dependencies) {
         throw new NotImplementedException()
     }
 

--- a/src/main/groovy/de/dkfz/roddy/execution/jobs/direct/synchronousexecution/DirectSynchronousExecutionJobManager.groovy
+++ b/src/main/groovy/de/dkfz/roddy/execution/jobs/direct/synchronousexecution/DirectSynchronousExecutionJobManager.groovy
@@ -13,7 +13,7 @@ import de.dkfz.roddy.tools.LoggerWrapper
 
 /**
  */
-public class DirectSynchronousExecutionJobManager extends BatchEuphoriaJobManager<DirectCommand> {
+class DirectSynchronousExecutionJobManager extends BatchEuphoriaJobManager<DirectCommand> {
 
     public static final LoggerWrapper logger = LoggerWrapper.getLogger(DirectSynchronousExecutionJobManager.class.getName());
 
@@ -32,7 +32,7 @@ public class DirectSynchronousExecutionJobManager extends BatchEuphoriaJobManage
     }
 
     @Override
-    public DirectCommand createCommand(BEJob job, String jobName, List<ProcessingCommands> processingCommands, File tool, Map<String, String> parameters, List<String> dependencies, List<String> arraySettings) {
+    public DirectCommand createCommand(BEJob job, String jobName, List<ProcessingCommands> processingCommands, File tool, Map<String, String> parameters, List<String> dependencies) {
         return null;
     }
 

--- a/src/test/groovy/de/dkfz/roddy/execution/jobs/cluster/pbs/PBSCommandTest.groovy
+++ b/src/test/groovy/de/dkfz/roddy/execution/jobs/cluster/pbs/PBSCommandTest.groovy
@@ -30,7 +30,7 @@ class PBSCommandTest {
     @Test
     void testAssembleVariableExportString() throws Exception {
         def mapOfParameters = ["a": "a", "b": "b"]
-        BEJob job = new BEJob("Test", new File("/tmp/test.sh"),null, null, new ResourceSet(ResourceSetSize.l, new BufferValue(1, BufferUnit.G), 4, 1, Duration.ofHours(1), null, null, null), null, mapOfParameters, null, null)
+        BEJob job = new BEJob("Test", new File("/tmp/test.sh"),null, null, new ResourceSet(ResourceSetSize.l, new BufferValue(1, BufferUnit.G), 4, 1, Duration.ofHours(1), null, null, null), mapOfParameters, null)
         PBSCommand cmd = new PBSCommand(null, job, "id", null, mapOfParameters, null, null, null, "/tmp/test.sh", null)
         String result = cmd.assembleVariableExportString()
         assert result.trim() == "-v a=a,b=b"
@@ -39,7 +39,7 @@ class PBSCommandTest {
     @Test
     void testAssembleDependencyStringWithoutDependencies() throws Exception {
         def mapOfParameters = ["a": "a", "b": "b"]
-        BEJob job = new BEJob("Test", new File("/tmp/test.sh"),null, null, new ResourceSet(ResourceSetSize.l, new BufferValue(1, BufferUnit.G), 4, 1, new TimeUnit("1h"), null, null, null), null, mapOfParameters, null, null)
+        BEJob job = new BEJob("Test", new File("/tmp/test.sh"),null, null, new ResourceSet(ResourceSetSize.l, new BufferValue(1, BufferUnit.G), 4, 1, new TimeUnit("1h"), null, null, null), mapOfParameters, null)
         PBSCommand cmd = new PBSCommand(null, job, "id", null, mapOfParameters, null, null, null, "/tmp/test.sh", null)
         String result = cmd.assembleDependencyString()
         assert result == ""


### PR DESCRIPTION
* Removed parentJob and parentJobID constructor parameters. Only the parentJobs remain, as the jobs contain the information isDirty, required by client code. Instead parentJobIDs and parentJobs can now be set by two (fluent) addParentJob[s,IDs] methods.
* Instead of silently selecting one of parentJobIDs or parentJobs in the constructor, client code (Roddy) now has to reconciliate lists of Jobs and IDs (see there)
* BEJob.getJobID now returns IDs, not Strings.
* Further array job code was removed, e.g. to simplify the BEJob constructor.