### PR TITLE
Moved BE to Groovy 2.4.9 (like Roddy). Added getQueueVariable() method.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ repositories {
 }
 
 dependencies {
-    compile 'org.codehaus.groovy:groovy-all:2.4.7'
+    compile 'org.codehaus.groovy:groovy-all:2.4.9'
     testCompile 'junit:junit:4.12'
     testCompile 'com.google.guava:guava:23.0'
     compile 'net.logstash.logback:logstash-logback-encoder:4.7'
@@ -90,4 +90,9 @@ task uberjar(type: Jar,dependsOn:[':compileJava',':compileGroovy']) {
         attributes 'Implementation-Version': version
     }
     exclude 'META-INF/*.RSA', 'META-INF/*.SF','META-INF/*.DSA'
+}
+
+// Fix Gradle version
+task wrapper(type: Wrapper) {
+    gradleVersion = '3.3'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     compile group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.3'
     compile group: 'commons-cli', name: 'commons-cli', version: '1.2'
     compile 'com.google.guava:guava:23.0'
-    compile 'com.github.eilslabs:RoddyToolLib:0.0.1'
+    compile 'com.github.eilslabs:RoddyToolLib:0.0.2'
 }
 
 task writePom {

--- a/src/main/groovy/de/dkfz/roddy/TestExecutionService.groovy
+++ b/src/main/groovy/de/dkfz/roddy/TestExecutionService.groovy
@@ -7,8 +7,8 @@
 package de.dkfz.roddy
 
 import de.dkfz.roddy.execution.BEExecutionService
+import de.dkfz.roddy.execution.io.LocalExecutionHelper
 import de.dkfz.roddy.execution.jobs.Command
-import de.dkfz.roddy.execution.io.ExecutionHelper
 import de.dkfz.roddy.execution.io.ExecutionResult
 import groovy.transform.CompileStatic
 
@@ -33,11 +33,11 @@ class TestExecutionService implements BEExecutionService {
 
     @Override
     ExecutionResult execute(String command, boolean waitFor = true) {
-        return ExecutionHelper.executeCommandWithExtendedResult("ssh ${user}@${server} ${command}")
+        return LocalExecutionHelper.executeCommandWithExtendedResult("ssh ${user}@${server} ${command}")
     }
 
     ExecutionResult executeLocal(String command) {
-        return ExecutionHelper.executeCommandWithExtendedResult(command)
+        return LocalExecutionHelper.executeCommandWithExtendedResult(command)
     }
 
     void copyFileToRemote(File file, File remote) {

--- a/src/main/groovy/de/dkfz/roddy/execution/jobs/BatchEuphoriaJobManager.groovy
+++ b/src/main/groovy/de/dkfz/roddy/execution/jobs/BatchEuphoriaJobManager.groovy
@@ -295,15 +295,9 @@ abstract class BatchEuphoriaJobManager<C extends Command> {
         this.jobArrayIndexIdentifier = jobArrayIndexIdentifier
     }
 
-    String getJobScratchIdentifier() {
-        return jobScratchIdentifier
-    }
-
-    void setJobScratchIdentifier(String jobScratchIdentifier) {
-        this.jobScratchIdentifier = jobScratchIdentifier
-    }
-
     abstract String getJobIdVariable()
+
+    abstract String getQueueVariable()
 
     abstract String getJobArrayIndexVariable()
 

--- a/src/main/groovy/de/dkfz/roddy/execution/jobs/Command.groovy
+++ b/src/main/groovy/de/dkfz/roddy/execution/jobs/Command.groovy
@@ -38,7 +38,7 @@ abstract class Command {
     /**
      * Parameters for the qsub command
      */
-    public final Map<String, String> parameters = [:]
+    public final LinkedHashMap<String, String> parameters = [:]
 
     /**
      * A list of named tags for the command object

--- a/src/main/groovy/de/dkfz/roddy/execution/jobs/cluster/lsf/LSFCommand.groovy
+++ b/src/main/groovy/de/dkfz/roddy/execution/jobs/cluster/lsf/LSFCommand.groovy
@@ -30,7 +30,7 @@ class LSFCommand extends Command {
     public static final String PARM_LOGPATH = " -eo "
     public static final String PARM_OUTPATH = " -oo "
     public static final String BSUB = "bsub"
-    public static final String PARM_DEPENDS = " -W depend="
+    public static final String PARM_DEPENDS = " -ti -w "
     public static final String PARM_MAIL = " -u "
     public static final String PARM_VARIABLES = " -env "
     public static final String PARM_JOBNAME = " -J "
@@ -217,8 +217,8 @@ class LSFCommand extends Command {
     private String prepareParentJobs(List<BEJobID> jobIds) {
         List<BEJobID> validJobIds = BEJob.uniqueValidJobIDs(jobIds)
         if (validJobIds.size() > 0) {
-            String joinedParentJobs = validJobIds.collect { "exit(${it}, 0)" }.join(" && ")
-            return " -w \"${joinedParentJobs} \""
+            String joinedParentJobs = validJobIds.collect { "done(${it})" }.join(" && ")
+            return " ${dependsSuperParameter} \"${joinedParentJobs}\" "
         } else {
             return ""
         }

--- a/src/main/groovy/de/dkfz/roddy/execution/jobs/cluster/lsf/LSFJobManager.groovy
+++ b/src/main/groovy/de/dkfz/roddy/execution/jobs/cluster/lsf/LSFJobManager.groovy
@@ -542,6 +542,11 @@ class LSFJobManager extends ClusterJobManager<LSFCommand> {
         return "LSB_SUBCWD"
     }
 
+    @Override
+    String getQueueVariable() {
+        return "LSB_QUEUE"
+    }
+
 
     protected int getPositionOfJobID() {
         return 0

--- a/src/main/groovy/de/dkfz/roddy/execution/jobs/cluster/lsf/rest/BatchEuphoriaJobManagerAdapter.groovy
+++ b/src/main/groovy/de/dkfz/roddy/execution/jobs/cluster/lsf/rest/BatchEuphoriaJobManagerAdapter.groovy
@@ -106,6 +106,11 @@ class BatchEuphoriaJobManagerAdapter extends ClusterJobManager {
     }
 
     @Override
+    String getQueueVariable() {
+        throw new NotImplementedException()
+    }
+
+    @Override
     String getJobArrayIndexVariable() {
         throw new NotImplementedException()
     }

--- a/src/main/groovy/de/dkfz/roddy/execution/jobs/cluster/lsf/rest/LSFRestJobManager.groovy
+++ b/src/main/groovy/de/dkfz/roddy/execution/jobs/cluster/lsf/rest/LSFRestJobManager.groovy
@@ -60,6 +60,11 @@ class LSFRestJobManager extends BatchEuphoriaJobManagerAdapter {
     }
 
     @Override
+    String getQueueVariable() {
+        return 'LSB_QUEUE'
+    }
+
+    @Override
     String getJobArrayIndexVariable() {
         return "LSB_JOBINDEX"
     }

--- a/src/main/groovy/de/dkfz/roddy/execution/jobs/cluster/pbs/PBSJobManager.groovy
+++ b/src/main/groovy/de/dkfz/roddy/execution/jobs/cluster/pbs/PBSJobManager.groovy
@@ -450,6 +450,11 @@ class PBSJobManager extends ClusterJobManager<PBSCommand> {
     }
 
     @Override
+    String getQueueVariable() {
+        return 'PBS_QUEUE'
+    }
+
+    @Override
     String getJobArrayIndexVariable() {
         return "PBS_ARRAYID"
     }

--- a/src/main/groovy/de/dkfz/roddy/execution/jobs/direct/synchronousexecution/DirectSynchronousExecutionJobManager.groovy
+++ b/src/main/groovy/de/dkfz/roddy/execution/jobs/direct/synchronousexecution/DirectSynchronousExecutionJobManager.groovy
@@ -118,6 +118,11 @@ class DirectSynchronousExecutionJobManager extends BatchEuphoriaJobManager<Direc
     }
 
     @Override
+    String getQueueVariable() {
+        return ''
+    }
+
+    @Override
     String getJobArrayIndexVariable() {
         throw new NotImplementedException()
     }


### PR DESCRIPTION
* Moved BE to Groovy 2.4.9 (like Roddy)
* Added getQueueVariable() method.
* Adapted to upstream name change of ExecutionHelper.