### PR TITLE
executeStartHeldJobs() and executeKillJobs() can now handle lists of …

### DIFF
--- a/src/main/groovy/de/dkfz/roddy/execution/jobs/BatchEuphoriaJobManager.groovy
+++ b/src/main/groovy/de/dkfz/roddy/execution/jobs/BatchEuphoriaJobManager.groovy
@@ -57,6 +57,7 @@ abstract class BatchEuphoriaJobManager<C extends Command> {
 
 
     BatchEuphoriaJobManager(BEExecutionService executionService, JobManagerOptions parms) {
+        assert(executionService)
         this.executionService = executionService
 
         this.isTrackingOfUserJobsEnabled = parms.trackUserJobsOnly

--- a/src/main/groovy/de/dkfz/roddy/execution/jobs/JobState.java
+++ b/src/main/groovy/de/dkfz/roddy/execution/jobs/JobState.java
@@ -7,6 +7,7 @@
 package de.dkfz.roddy.execution.jobs;
 
 import java.io.Serializable;
+import java.util.Arrays;
 
 /**
  * A generic jobState for jobs.
@@ -54,7 +55,7 @@ public enum JobState implements Serializable {
     }
 
     public static boolean _isPlannedOrRunning(JobState jobState) {
-        return jobState == JobState.RUNNING || jobState == JobState.QUEUED || jobState == JobState.HOLD;
+        return Arrays.asList(JobState.RUNNING, JobState.QUEUED, JobState.HOLD, JobState.STARTED, JobState.UNSTARTED).contains(jobState);
     }
 
     public boolean isDummy() {

--- a/src/main/groovy/de/dkfz/roddy/execution/jobs/cluster/lsf/LSFJobManager.groovy
+++ b/src/main/groovy/de/dkfz/roddy/execution/jobs/cluster/lsf/LSFJobManager.groovy
@@ -74,11 +74,6 @@ class LSFJobManager extends AbstractLSFJobManager {
     }
 
     @Override
-    protected ExecutionResult executeStartHeldJobs(List<BEJobID> jobIDs) {
-        executionService.execute("bresume ${jobIDs*.id.join(" ")}")
-    }
-
-    @Override
     GenericJobInfo parseGenericJobInfo(String commandString) {
         return new LSFCommandParser(commandString).toGenericJobInfo();
     }
@@ -234,8 +229,14 @@ class LSFJobManager extends AbstractLSFJobManager {
 
     @Override
     protected ExecutionResult executeKillJobs(List<BEJobID> jobIDs) {
-        logger.always("${LSF_COMMAND_DELETE_JOBS} ${jobIDs.join(" ")}")
-        return executionService.execute("${LSF_COMMAND_DELETE_JOBS} ${jobIDs*.id.join(" ")}", false)
+        String command = "bkill ${jobIDs*.id.join(" ")}"
+        return executionService.execute(command, false)
+    }
+
+    @Override
+    protected ExecutionResult executeStartHeldJobs(List<BEJobID> jobIDs) {
+        String command = "bresume ${jobIDs*.id.join(" ")}"
+        return executionService.execute(command, false)
     }
 
     @Override

--- a/src/main/groovy/de/dkfz/roddy/execution/jobs/cluster/lsf/rest/LSFRestJobManager.groovy
+++ b/src/main/groovy/de/dkfz/roddy/execution/jobs/cluster/lsf/rest/LSFRestJobManager.groovy
@@ -234,16 +234,8 @@ class LSFRestJobManager extends AbstractLSFJobManager {
     }
 
     /**
-     * Suspend given job
-     * @param job
-     * /
-    void suspendJob(BEJob job) {
-        submitCommand("bstop ${job.getJobID()}")
-    }*/
-
-    /**
-     * Resume given job
-     * @param job
+     * Resume given jobs
+     * @param jobs
      */
     @Override
     protected RestResult executeStartHeldJobs(List<BEJobID> jobIDs) {

--- a/src/main/groovy/de/dkfz/roddy/execution/jobs/cluster/pbs/PBSJobManager.groovy
+++ b/src/main/groovy/de/dkfz/roddy/execution/jobs/cluster/pbs/PBSJobManager.groovy
@@ -33,7 +33,6 @@ class PBSJobManager extends ClusterJobManager<PBSCommand> {
 
     private static final String PBS_COMMAND_QUERY_STATES = "qstat -t"
     private static final String PBS_COMMAND_QUERY_STATES_FULL = "qstat -f"
-    private static final String PBS_COMMAND_DELETE_JOBS = "qdel"
     private static final String WITH_DELIMITER = '(?=(%1$s))'
 
     PBSJobManager(BEExecutionService executionService, JobManagerOptions parms) {
@@ -53,7 +52,7 @@ class PBSJobManager extends ClusterJobManager<PBSCommand> {
     }
 
     /**
-     * For BPS, we enable hold jobs by default.
+     * For PBS, we enable hold jobs by default.
      * If it is not enabled, we might run into the problem, that job dependencies cannot be
      * resolved early enough due to timing problems.
      * @return
@@ -63,8 +62,11 @@ class PBSJobManager extends ClusterJobManager<PBSCommand> {
 
     @Override
     protected ExecutionResult executeStartHeldJobs(List<BEJobID> jobIDs) {
-        executionService.execute("qrls ${jobIDs*.id.join(" ")}")
+        String command = "qrls ${jobIDs*.id.join(" ")}"
+        return executionService.execute(command, false)
     }
+
+
 
     @Override
     ProcessingParameters convertResourceSet(BEJob job, ResourceSet resourceSet) {
@@ -164,7 +166,6 @@ class PBSJobManager extends ClusterJobManager<PBSCommand> {
         return result
     }
 
-
     @Override
     String getJobIdVariable() {
         return "PBS_JOBID"
@@ -235,13 +236,10 @@ class PBSJobManager extends ClusterJobManager<PBSCommand> {
         return queriedExtendedStates
     }
 
-
     @Override
     ExecutionResult executeKillJobs(List<BEJobID> jobIDs) {
-        StringBuilder killJobsCommand = new StringBuilder(PBS_COMMAND_DELETE_JOBS)
-        killJobsCommand << " " << jobIDs*.id.join(" ")
-        logger.always(killJobsCommand.toString())
-        return executionService.execute(killJobsCommand.toString(), false)
+        String command = "qdel ${jobIDs*.id.join(" ")}"
+        return executionService.execute(command, false)
     }
 
     @Override

--- a/src/main/groovy/de/dkfz/roddy/execution/jobs/cluster/pbs/PBSJobManager.groovy
+++ b/src/main/groovy/de/dkfz/roddy/execution/jobs/cluster/pbs/PBSJobManager.groovy
@@ -117,9 +117,6 @@ class PBSJobManager extends ClusterJobManager<PBSCommand> {
 
     @Override
     protected Map<BEJobID, JobState> queryJobStates(List<BEJobID> jobIDs) {
-        if (!executionService.isAvailable())
-            return
-
         StringBuilder queryCommand = new StringBuilder(getQueryCommand())
 
         if (jobIDs && jobIDs.size() < 10) {

--- a/src/main/groovy/de/dkfz/roddy/execution/jobs/direct/synchronousexecution/DirectSynchronousExecutionJobManager.groovy
+++ b/src/main/groovy/de/dkfz/roddy/execution/jobs/direct/synchronousexecution/DirectSynchronousExecutionJobManager.groovy
@@ -45,7 +45,18 @@ class DirectSynchronousExecutionJobManager extends BatchEuphoriaJobManager<Direc
     }
 
     @Override
-    ExecutionResult executeKillJobs(List<BEJobID> executedJobs) { null }
+    ExecutionResult executeKillJobs(List<BEJobID> jobIDs) {
+        String command = "kill -s SIGKILL ${jobIDs*.id.join(" ")}"
+        logger.always(command)
+        return executionService.execute(command, false)
+    }
+
+    @Override
+    protected ExecutionResult executeStartHeldJobs(List<BEJobID> jobIDs) {
+        String command = "kill -s SIGCONT ${jobIDs*.id.join(" ")}"
+        logger.always(command)
+        return executionService.execute(command, false)
+    }
 
     @Override
     void addToListOfStartedJobs(BEJob job) {}
@@ -53,16 +64,6 @@ class DirectSynchronousExecutionJobManager extends BatchEuphoriaJobManager<Direc
     @Override
     String getJobIdVariable() {
         return ""
-    }
-
-    String getSpecificJobIDIdentifier() {
-        logger.severe("BEJob jobName for " + getClass().getName() + " should be configurable")
-        return '"$$"'
-    }
-
-    String getSpecificJobScratchIdentifier() {
-        logger.severe("BEJob scratch for " + getClass().getName() + " should be configurable")
-        return '/data/roddyScratch/$$'
     }
 
     String getJobNameVariable() {
@@ -125,9 +126,6 @@ class DirectSynchronousExecutionJobManager extends BatchEuphoriaJobManager<Direc
 
         return jobResult
     }
-
-    @Override
-    ExecutionResult executeStartHeldJobs(List<BEJobID> jobs) { null }
 
     @Override
     ProcessingParameters convertResourceSet(BEJob job, ResourceSet resourceSet) {

--- a/src/main/groovy/de/dkfz/roddy/execution/jobs/direct/synchronousexecution/DirectSynchronousExecutionJobManager.groovy
+++ b/src/main/groovy/de/dkfz/roddy/execution/jobs/direct/synchronousexecution/DirectSynchronousExecutionJobManager.groovy
@@ -47,14 +47,12 @@ class DirectSynchronousExecutionJobManager extends BatchEuphoriaJobManager<Direc
     @Override
     ExecutionResult executeKillJobs(List<BEJobID> jobIDs) {
         String command = "kill -s SIGKILL ${jobIDs*.id.join(" ")}"
-        logger.always(command)
         return executionService.execute(command, false)
     }
 
     @Override
     protected ExecutionResult executeStartHeldJobs(List<BEJobID> jobIDs) {
         String command = "kill -s SIGCONT ${jobIDs*.id.join(" ")}"
-        logger.always(command)
         return executionService.execute(command, false)
     }
 

--- a/src/test/groovy/de/dkfz/roddy/execution/jobs/cluster/pbs/PBSCommandParserTest.groovy
+++ b/src/test/groovy/de/dkfz/roddy/execution/jobs/cluster/pbs/PBSCommandParserTest.groovy
@@ -6,7 +6,10 @@
 
 package de.dkfz.roddy.execution.jobs.cluster.pbs
 
+import de.dkfz.roddy.execution.BEExecutionService
+import de.dkfz.roddy.execution.io.ExecutionResult
 import de.dkfz.roddy.execution.jobs.BatchEuphoriaJobManager
+import de.dkfz.roddy.execution.jobs.Command
 import de.dkfz.roddy.execution.jobs.JobManagerOptions
 import groovy.transform.CompileStatic
 import org.junit.BeforeClass
@@ -24,7 +27,42 @@ class PBSCommandParserTest {
 
     @BeforeClass
     static void setup() {
-        testJobManager = new PBSJobManager(null, JobManagerOptions.create().setCreateDaemon(false).build())
+        testJobManager = new PBSJobManager(new BEExecutionService() {
+            @Override
+            ExecutionResult execute(Command command) {
+                return null
+            }
+
+            @Override
+            ExecutionResult execute(Command command, boolean waitFor) {
+                return null
+            }
+
+            @Override
+            ExecutionResult execute(String command) {
+                return null
+            }
+
+            @Override
+            ExecutionResult execute(String command, boolean waitFor) {
+                return null
+            }
+
+            @Override
+            ExecutionResult execute(String command, boolean waitForIncompatibleClassChangeError, OutputStream outputStream) {
+                return null
+            }
+
+            @Override
+            boolean isAvailable() {
+                return false
+            }
+
+            @Override
+            File queryWorkingDirectory() {
+                return null
+            }
+        }, JobManagerOptions.create().setCreateDaemon(false).build())
     }
 
     @Test


### PR DESCRIPTION
…only fake jobs. All throw BEExceptions upon error.

* Made code more heterogenous.
* Removed DirectSynchronousManager getSpecificJobScratchIdentifier and getSpecificJobIDIdentifier.