### PR TITLE
PBS_JOBID needs to be quoted in logfile names, or it will be evaluate…

### DIFF
--- a/src/main/groovy/de/dkfz/roddy/execution/jobs/cluster/pbs/PBSCommand.groovy
+++ b/src/main/groovy/de/dkfz/roddy/execution/jobs/cluster/pbs/PBSCommand.groovy
@@ -80,9 +80,9 @@ class PBSCommand extends SubmissionCommand {
         if (!jobLog.out && !jobLog.error) {
             return "-k"
         } else if (jobLog.out == jobLog.error) {
-            return "${joinLogParameter} -o ${jobLog.out.replace(JobLog.JOB_ID, '$PBS_JOBID')}"
+            return "${joinLogParameter} -o \"${jobLog.out.replace(JobLog.JOB_ID, '\\$PBS_JOBID')}\""
         } else {
-            return "-o ${jobLog.out.replace(JobLog.JOB_ID, '$PBS_JOBID')} -e ${jobLog.error.replace(JobLog.JOB_ID, '$PBS_JOBID')}"
+            return "-o \"${jobLog.out.replace(JobLog.JOB_ID, '\\$PBS_JOBID')} -e ${jobLog.error.replace(JobLog.JOB_ID, '\\$PBS_JOBID')}\""
         }
     }
 

--- a/src/main/groovy/de/dkfz/roddy/execution/jobs/cluster/sge/SGEJobManager.groovy
+++ b/src/main/groovy/de/dkfz/roddy/execution/jobs/cluster/sge/SGEJobManager.groovy
@@ -110,4 +110,15 @@ class SGEJobManager extends PBSJobManager {
                 "   1191 0.00000 r140710_09 seqware hqw 07 / 10 / 2014 09:51:48 1",
                 "   1192 0.00000 r140710_09 seqware hqw 07 / 10 / 2014 09:51:48 1")
     }
+
+    @Override
+    String getJobIdVariable() {
+        return "JOBID"
+    }
+
+    @Override
+    String getJobNameVariable() {
+        return "JOB_NAME"
+    }
+
 }


### PR DESCRIPTION
…d on submission host. Fixed. Note that the full JobID in PBS is a number dot appendend scheduling server. This means the .o$PBS_JOBID here is a rather lengthly string. Unfortunately, I do not see a way to get the short Job ID -- just the number -- into the logfile name, as there apparently is no variable provided by PBS.

Additionally added getJobIdVariable() and getJobNameVariable() to SGEJobManager.