### PR TITLE
Allow toggling the copying of the environment to execution hosts

### DIFF
--- a/src/main/groovy/de/dkfz/roddy/execution/jobs/BatchEuphoriaJobManager.groovy
+++ b/src/main/groovy/de/dkfz/roddy/execution/jobs/BatchEuphoriaJobManager.groovy
@@ -62,7 +62,7 @@ abstract class BatchEuphoriaJobManager<C extends Command> {
     boolean requestQueueIsEnabled
     boolean requestCoresIsEnabled
     boolean requestStorageIsEnabled
-    boolean enforcePassEnvironment
+    Optional<Boolean> passEnvironment = Optional.empty()
 
     BatchEuphoriaJobManager(BEExecutionService executionService, JobManagerOptions parms) {
         assert(executionService)
@@ -87,7 +87,7 @@ abstract class BatchEuphoriaJobManager<C extends Command> {
         this.requestQueueIsEnabled = parms.requestQueueIsEnabled
         this.requestCoresIsEnabled = parms.requestCoresIsEnabled
         this.requestStorageIsEnabled = parms.requestStorageIsEnabled
-        this.enforcePassEnvironment = parms.enforcePassEnvironment
+        this.passEnvironment = parms.passEnvironment
 
         if (parms.createDaemon) {
             createUpdateDaemonThread()

--- a/src/main/groovy/de/dkfz/roddy/execution/jobs/BatchEuphoriaJobManager.groovy
+++ b/src/main/groovy/de/dkfz/roddy/execution/jobs/BatchEuphoriaJobManager.groovy
@@ -62,7 +62,7 @@ abstract class BatchEuphoriaJobManager<C extends Command> {
     boolean requestQueueIsEnabled
     boolean requestCoresIsEnabled
     boolean requestStorageIsEnabled
-    boolean enforcePassEnvironmentExportParameter
+    boolean enforcePassEnvironment
 
     BatchEuphoriaJobManager(BEExecutionService executionService, JobManagerOptions parms) {
         assert(executionService)
@@ -87,7 +87,7 @@ abstract class BatchEuphoriaJobManager<C extends Command> {
         this.requestQueueIsEnabled = parms.requestQueueIsEnabled
         this.requestCoresIsEnabled = parms.requestCoresIsEnabled
         this.requestStorageIsEnabled = parms.requestStorageIsEnabled
-        this.enforcePassEnvironmentExportParameter = parms.enforcePassEnvironmentExportParameter
+        this.enforcePassEnvironment = parms.enforcePassEnvironment
 
         if (parms.createDaemon) {
             createUpdateDaemonThread()

--- a/src/main/groovy/de/dkfz/roddy/execution/jobs/JobManagerOptions.groovy
+++ b/src/main/groovy/de/dkfz/roddy/execution/jobs/JobManagerOptions.groovy
@@ -57,7 +57,7 @@ class JobManagerOptions {
     /**
      * Tell the job manager to pass the current environment or fall back to the underlying job systems default settings.
      */
-    boolean enforcePassEnvironmentExportParameter
+    boolean enforcePassEnvironment
 
     Map<String, String> additionalOptions
 
@@ -84,7 +84,7 @@ class JobManagerOptionsBuilder {
         requestQueueIsEnabled = true
         requestCoresIsEnabled = true
         requestStorageIsEnabled = false  // Defaults to false, not supported now.
-        enforcePassEnvironmentExportParameter = true  // Sometimes true, sometimes false in the job system. But we can forcibly enable it.
+        enforcePassEnvironment = true  // Sometimes true, sometimes false in the job system. But we can forcibly enable it.
         additionalOptions = [:]
     }
 }

--- a/src/main/groovy/de/dkfz/roddy/execution/jobs/JobManagerOptions.groovy
+++ b/src/main/groovy/de/dkfz/roddy/execution/jobs/JobManagerOptions.groovy
@@ -57,7 +57,7 @@ class JobManagerOptions {
     /**
      * Tell the job manager to pass the current environment or fall back to the underlying job systems default settings.
      */
-    boolean enforcePassEnvironment
+    Optional<Boolean> passEnvironment
 
     Map<String, String> additionalOptions
 
@@ -84,7 +84,7 @@ class JobManagerOptionsBuilder {
         requestQueueIsEnabled = true
         requestCoresIsEnabled = true
         requestStorageIsEnabled = false  // Defaults to false, not supported now.
-        enforcePassEnvironment = true  // Sometimes true, sometimes false in the job system. But we can forcibly enable it.
+        passEnvironment = Optional.empty()
         additionalOptions = [:]
     }
 }

--- a/src/main/groovy/de/dkfz/roddy/execution/jobs/SubmissionCommand.groovy
+++ b/src/main/groovy/de/dkfz/roddy/execution/jobs/SubmissionCommand.groovy
@@ -42,14 +42,14 @@ abstract class SubmissionCommand extends Command {
      *
      * @return
      */
-    boolean getPassLocalEnvironment() {
+    Optional<Boolean> getPassLocalEnvironment() {
         if (passEnvironment.present) {
-            return passEnvironment.get()
+            return passEnvironment
         } else {
             if (parentJobManager.passEnvironment.present) {
-                return parentJobManager.passEnvironment.get()
+                return parentJobManager.passEnvironment
             } else {
-                return false
+                return Optional.empty()
             }
         }
     }
@@ -65,7 +65,7 @@ abstract class SubmissionCommand extends Command {
 
         // collect parameters for job submission
         List<String> parameters = []
-        if (passLocalEnvironment) parameters << getEnvironmentExportParameter()
+        parameters << " " + getEnvironmentExportParameter() + " "
         parameters << getJobNameParameter()
         if (holdJobsOnStart) parameters << getHoldParameter()
         parameters << getAccountParameter(accountName)

--- a/src/main/groovy/de/dkfz/roddy/execution/jobs/SubmissionCommand.groovy
+++ b/src/main/groovy/de/dkfz/roddy/execution/jobs/SubmissionCommand.groovy
@@ -18,7 +18,7 @@ abstract class SubmissionCommand extends Command {
     /**
      *  Should the local environment during the submission be copied to the execution hosts?
      */
-    private boolean copyExecutionEnvironment = true
+    private Optional<Boolean> passEnvironment = Optional.empty()
 
     /**
      * A command to be executed on the cluster head node, in particular qsub, bsub, qstat, etc.
@@ -34,11 +34,24 @@ abstract class SubmissionCommand extends Command {
     }
 
     /**
-     * The JobManager can force the passing of the environment to the execution host.
+     * JobManager and SubmissionCommand together determine, whether the environment should be passed.
+     *
+     * * If the Command value is set to true or false, the JobManager value is overruled.
+     * * If the Command value is not set, the JobManager value is the fallback.
+     * * If neither of JobManager and Command is defined, return false.
+     *
      * @return
      */
     boolean getPassLocalEnvironment() {
-        return copyExecutionEnvironment || parentJobManager.enforcePassEnvironment
+        if (passEnvironment.present) {
+            return passEnvironment.get()
+        } else {
+            if (parentJobManager.passEnvironment.present) {
+                return parentJobManager.passEnvironment.get()
+            } else {
+                return false
+            }
+        }
     }
 
     @Override

--- a/src/main/groovy/de/dkfz/roddy/execution/jobs/SubmissionCommand.groovy
+++ b/src/main/groovy/de/dkfz/roddy/execution/jobs/SubmissionCommand.groovy
@@ -14,6 +14,12 @@ import static de.dkfz.roddy.StringConstants.EMPTY
 
 @CompileStatic
 abstract class SubmissionCommand extends Command {
+
+    /**
+     *  Should the local environment during the submission be copied to the execution hosts?
+     */
+    private boolean copyExecutionEnvironment = true
+
     /**
      * A command to be executed on the cluster head node, in particular qsub, bsub, qstat, etc.
      *
@@ -27,6 +33,14 @@ abstract class SubmissionCommand extends Command {
         super(parentJobManager, job, jobName, parameters)
     }
 
+    /**
+     * The JobManager can force the passing of the environment to the execution host.
+     * @return
+     */
+    boolean getPassLocalEnvironment() {
+        return copyExecutionEnvironment || parentJobManager.enforcePassEnvironment
+    }
+
     @Override
     String toString() {
 
@@ -35,11 +49,10 @@ abstract class SubmissionCommand extends Command {
         String groupList = parentJobManager.getUserGroup()
         String accountName = job.customUserAccount ?: parentJobManager.getUserAccount()
         boolean holdJobsOnStart = parentJobManager.isHoldJobsEnabled()
-        boolean forcePassEnv = parentJobManager.enforcePassEnvironmentExportParameter
 
         // collect parameters for job submission
         List<String> parameters = []
-        if (forcePassEnv) parameters << getEnvironmentExportParameter()
+        if (passLocalEnvironment) parameters << getEnvironmentExportParameter()
         parameters << getJobNameParameter()
         if (holdJobsOnStart) parameters << getHoldParameter()
         parameters << getAccountParameter(accountName)

--- a/src/main/groovy/de/dkfz/roddy/execution/jobs/SubmissionCommand.groovy
+++ b/src/main/groovy/de/dkfz/roddy/execution/jobs/SubmissionCommand.groovy
@@ -65,7 +65,7 @@ abstract class SubmissionCommand extends Command {
 
         // collect parameters for job submission
         List<String> parameters = []
-        parameters << " " + getEnvironmentExportParameter() + " "
+        parameters << getEnvironmentExportParameter()
         parameters << getJobNameParameter()
         if (holdJobsOnStart) parameters << getHoldParameter()
         parameters << getAccountParameter(accountName)

--- a/src/main/groovy/de/dkfz/roddy/execution/jobs/cluster/lsf/LSFCommand.groovy
+++ b/src/main/groovy/de/dkfz/roddy/execution/jobs/cluster/lsf/LSFCommand.groovy
@@ -48,7 +48,7 @@ class LSFCommand extends SubmissionCommand {
 
     @Override
     protected String getEnvironmentExportParameter() {
-        // TODO Is this really not supported?
+        // Part of the variable export string. See assembleVariableExportString().
         return ""
     }
 
@@ -124,40 +124,41 @@ class LSFCommand extends SubmissionCommand {
      *
      * Note that variable quoting is left to the client code. The whole -env parameter-value is quoted with ".
      *
-     * * @return    a String of '-env "[all|none](, varName[=varValue](, varName[=varValue])*)?"'
+     * * @return    a String of '-env "[all|none|](, varName[=varValue](, varName[=varValue])*)?"'
      */
     @Override
     String assembleVariableExportString() {
-        StringBuilder qsubCall = new StringBuilder()
-        qsubCall << "-env " << "\""
-        if (passLocalEnvironment) {
-            qsubCall << "all"
-        } else {
-            qsubCall << "none"
-        }
+        List<String> environmentStrings = new LinkedList<>()
+
+        if (passLocalEnvironment.isPresent()) {
+            if (passLocalEnvironment.get()) {
+                environmentStrings.add("all")
+            } else {
+                environmentStrings.add("none")
+            }
+        } // According to the docs (Version 10.1.0), undefined means "all".
 
         if (job.parameters.containsKey("CONFIG_FILE") && job.parameters.containsKey("PARAMETER_FILE")) {
             // This code is exclusively meant to quickfix Roddy. Remove this branch if Roddy is fixed.
             // WARNING: Note the additional space before the parameter delimiter! It is necessary for bsub -env but must not be there for qsub in PBS!
-            qsubCall << ", CONFIG_FILE=" << job.parameters["CONFIG_FILE"] << ", PARAMETER_FILE=" << job.parameters["PARAMETER_FILE"]
+            environmentStrings.add("CONFIG_FILE=" + job.parameters["CONFIG_FILE"])
+            environmentStrings.add("PARAMETER_FILE=" + job.parameters["PARAMETER_FILE"])
 
             if (job.parameters.containsKey("debugWrapInScript")) {
-                qsubCall << ", " << "debugWrapInScript=" << job.parameters["debugWrapInScript"]
+                environmentStrings.add("debugWrapInScript=" + job.parameters["debugWrapInScript"])
             }
         } else {
             if (!parameters.isEmpty()) {
-                qsubCall << ", " << parameters.collect { key, value ->
+                environmentStrings.addAll(parameters.collect { key, value ->
                     if (null == value)
                         key                   // returning just the variable name make bsub take the value form the *bsub-commands* execution environment
                     else
                         "${key}=${value}"     // sets value to value
-                }.join(", ")
+                } as List)
             }
         }
 
-        qsubCall << "\""
-
-        return qsubCall
+        return "\"" + environmentStrings.join(", ") + "\""
     }
 
     protected String getAdditionalCommandParameters() {

--- a/src/main/groovy/de/dkfz/roddy/execution/jobs/cluster/lsf/LSFCommand.groovy
+++ b/src/main/groovy/de/dkfz/roddy/execution/jobs/cluster/lsf/LSFCommand.groovy
@@ -118,7 +118,7 @@ class LSFCommand extends SubmissionCommand {
     // TODO Code duplication with PBSCommand. Check also DirectSynchronousCommand.
     /**
      * Compose the -env parameter of bsub. This supports the 'none' and 'all' parameters to clean the bsub environment or to copy the full
-     * environment during submission to the execution host. This depends on whether the `copyExecutionEnvironment` field is set (default=true). Also
+     * environment during submission to the execution host. This depends on whether the `passEnvironment` field is set (default=true). Also
      * copying specific variables (just use variable name pointing to null value in the `parameters` hash) and setting to a specific value are
      * supported.
      *

--- a/src/main/groovy/de/dkfz/roddy/execution/jobs/cluster/lsf/LSFCommand.groovy
+++ b/src/main/groovy/de/dkfz/roddy/execution/jobs/cluster/lsf/LSFCommand.groovy
@@ -30,11 +30,6 @@ class LSFCommand extends SubmissionCommand {
 
     protected List<String> dependencyIDs
 
-    /**
-     *
-     */
-    public boolean copyExecutionEnvironment = true
-
     protected final List<ProcessingParameters> processingParameters
 
     /**
@@ -135,7 +130,7 @@ class LSFCommand extends SubmissionCommand {
     String assembleVariableExportString() {
         StringBuilder qsubCall = new StringBuilder()
         qsubCall << "-env " << "\""
-        if (copyExecutionEnvironment) {
+        if (passLocalEnvironment) {
             qsubCall << "all"
         } else {
             qsubCall << "none"

--- a/src/main/groovy/de/dkfz/roddy/execution/jobs/cluster/lsf/LSFCommand.groovy
+++ b/src/main/groovy/de/dkfz/roddy/execution/jobs/cluster/lsf/LSFCommand.groovy
@@ -132,33 +132,33 @@ class LSFCommand extends SubmissionCommand {
 
         if (passLocalEnvironment.isPresent()) {
             if (passLocalEnvironment.get()) {
-                environmentStrings.add("all")
+                environmentStrings << "all"
             } else {
-                environmentStrings.add("none")
+                environmentStrings << "none"
             }
         } // According to the docs (Version 10.1.0), undefined means "all".
 
         if (job.parameters.containsKey("CONFIG_FILE") && job.parameters.containsKey("PARAMETER_FILE")) {
             // This code is exclusively meant to quickfix Roddy. Remove this branch if Roddy is fixed.
             // WARNING: Note the additional space before the parameter delimiter! It is necessary for bsub -env but must not be there for qsub in PBS!
-            environmentStrings.add("CONFIG_FILE=" + job.parameters["CONFIG_FILE"])
-            environmentStrings.add("PARAMETER_FILE=" + job.parameters["PARAMETER_FILE"])
+            environmentStrings << "CONFIG_FILE=" + job.parameters["CONFIG_FILE"]
+            environmentStrings << "PARAMETER_FILE=" + job.parameters["PARAMETER_FILE"]
 
             if (job.parameters.containsKey("debugWrapInScript")) {
-                environmentStrings.add("debugWrapInScript=" + job.parameters["debugWrapInScript"])
+                environmentStrings << "debugWrapInScript=" + job.parameters["debugWrapInScript"]
             }
         } else {
             if (!parameters.isEmpty()) {
-                environmentStrings.addAll(parameters.collect { key, value ->
+                environmentStrings += parameters.collect { key, value ->
                     if (null == value)
                         key                   // returning just the variable name make bsub take the value form the *bsub-commands* execution environment
                     else
                         "${key}=${value}"     // sets value to value
-                } as List)
+                } as List
             }
         }
 
-        return "\"" + environmentStrings.join(", ") + "\""
+        return '"' + environmentStrings.join(", ") + '"'
     }
 
     protected String getAdditionalCommandParameters() {

--- a/src/main/groovy/de/dkfz/roddy/execution/jobs/cluster/pbs/PBSCommand.groovy
+++ b/src/main/groovy/de/dkfz/roddy/execution/jobs/cluster/pbs/PBSCommand.groovy
@@ -57,7 +57,13 @@ class PBSCommand extends SubmissionCommand {
 
     @Override
     protected String getEnvironmentExportParameter() {
-        return " -V "
+        if (passLocalEnvironment.isPresent()) {
+            if (passLocalEnvironment.get())
+                return "-V"
+            else
+                return ""
+        } else
+            return ""
     }
 
     @Override

--- a/src/test/groovy/de/dkfz/roddy/batcheuphoria/jobs/JobManagerOptionsTest.groovy
+++ b/src/test/groovy/de/dkfz/roddy/batcheuphoria/jobs/JobManagerOptionsTest.groovy
@@ -26,5 +26,6 @@ class JobManagerOptionsTest {
         assert parms.strictMode == true
         assert parms.updateInterval == Duration.ofMinutes(5)
         assert parms.createDaemon == false
+        assert !parms.passEnvironment.isPresent()
     }
 }


### PR DESCRIPTION
Missing: Allow setting this feature via the command, unless enforced by the JobManager.